### PR TITLE
Added chat messages API implementation.

### DIFF
--- a/backend/crates/domain/src/chat/errors.rs
+++ b/backend/crates/domain/src/chat/errors.rs
@@ -8,4 +8,6 @@ pub enum ChatSessionError {
     TitleTooLong,
     #[error("Repository failure: {0}")]
     RepoFailure(String),
+    #[error("Invalid message role")]
+    InvalidRole,
 }

--- a/backend/crates/domain/src/chat/messages.rs
+++ b/backend/crates/domain/src/chat/messages.rs
@@ -1,0 +1,11 @@
+use crate::chat::values::{MessageId, MessageRole, SessionId};
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone)]
+pub struct ChatMessage {
+    pub id: MessageId,
+    pub session_id: SessionId,
+    pub role: MessageRole,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}

--- a/backend/crates/domain/src/chat/mod.rs
+++ b/backend/crates/domain/src/chat/mod.rs
@@ -1,10 +1,12 @@
 pub mod errors;
+pub mod messages;
 pub mod repositories;
 pub mod service;
 pub mod session;
 pub mod values;
 
 pub use errors::*;
+pub use messages::*;
 pub use repositories::*;
 pub use session::*;
 pub use values::*;

--- a/backend/crates/domain/src/chat/repositories.rs
+++ b/backend/crates/domain/src/chat/repositories.rs
@@ -1,4 +1,5 @@
 use crate::chat::errors::ChatSessionError;
+use crate::chat::messages::ChatMessage;
 use crate::chat::session::ChatSession;
 use crate::chat::values::SessionId;
 use async_trait::async_trait;
@@ -7,4 +8,13 @@ use async_trait::async_trait;
 pub trait ChatSessionRepository {
     async fn create(&self, chat_session: ChatSession) -> Result<ChatSession, ChatSessionError>;
     async fn get_by_id(&self, id: SessionId) -> Result<ChatSession, ChatSessionError>;
+}
+
+#[async_trait]
+pub trait ChatMessageRepository {
+    async fn create(&self, message: ChatMessage) -> Result<ChatMessage, ChatSessionError>;
+    async fn list_by_session_id(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Vec<ChatMessage>, ChatSessionError>;
 }

--- a/backend/crates/domain/src/chat/values.rs
+++ b/backend/crates/domain/src/chat/values.rs
@@ -1,4 +1,6 @@
 use crate::chat::errors::ChatSessionError;
+use std::fmt::Display;
+use std::str::FromStr;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,5 +41,50 @@ impl From<SessionTitle> for String {
 impl From<String> for SessionTitle {
     fn from(title: String) -> Self {
         Self(title)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageId(Uuid);
+
+impl From<MessageId> for Uuid {
+    fn from(id: MessageId) -> Self {
+        id.0
+    }
+}
+
+impl From<Uuid> for MessageId {
+    fn from(id: Uuid) -> Self {
+        Self(id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MessageRole {
+    System,
+    User,
+    Assistant,
+}
+
+impl Display for MessageRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MessageRole::System => write!(f, "system"),
+            MessageRole::User => write!(f, "user"),
+            MessageRole::Assistant => write!(f, "assistant"),
+        }
+    }
+}
+
+impl FromStr for MessageRole {
+    type Err = ChatSessionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "system" => Ok(MessageRole::System),
+            "user" => Ok(MessageRole::User),
+            "assistant" => Ok(MessageRole::Assistant),
+            _ => Err(ChatSessionError::InvalidRole),
+        }
     }
 }

--- a/backend/crates/infra/migrations/20251125204049_create_chat_messages_table.down.sql
+++ b/backend/crates/infra/migrations/20251125204049_create_chat_messages_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE chat_messages;

--- a/backend/crates/infra/migrations/20251125204049_create_chat_messages_table.up.sql
+++ b/backend/crates/infra/migrations/20251125204049_create_chat_messages_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE chat_messages (
+    id UUID PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+    role VARCHAR(50) NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL
+);

--- a/backend/crates/infra/src/sqlx/chat/error.rs
+++ b/backend/crates/infra/src/sqlx/chat/error.rs
@@ -1,6 +1,0 @@
-use domain::chat::ChatSessionError;
-use sqlx::Error;
-
-pub fn from_sqlx_error(error: Error) -> ChatSessionError {
-    ChatSessionError::RepoFailure(error.to_string())
-}

--- a/backend/crates/infra/src/sqlx/chat/mod.rs
+++ b/backend/crates/infra/src/sqlx/chat/mod.rs
@@ -1,7 +1,5 @@
-pub mod error;
 pub mod repositories;
 pub mod types;
 
-pub use error::*;
 pub use repositories::*;
 pub use types::*;

--- a/backend/crates/infra/src/sqlx/chat/repositories.rs
+++ b/backend/crates/infra/src/sqlx/chat/repositories.rs
@@ -1,8 +1,11 @@
-use crate::sqlx::chat::{ChatSessionRow, from_sqlx_error};
+use crate::sqlx::chat::{ChatMessageRow, ChatSessionRow};
 use async_trait::async_trait;
+use domain::chat::{ChatMessage, ChatMessageRepository};
 use domain::chat::{ChatSession, ChatSessionError, ChatSessionRepository, SessionId};
 use sqlx::PgPool;
 use uuid::Uuid;
+
+// ChatSessionRepository implementation
 
 pub struct SqlxChatSessionRepository {
     pool: PgPool,
@@ -27,7 +30,7 @@ impl ChatSessionRepository for SqlxChatSessionRepository {
         )
         .fetch_one(&self.pool)
         .await
-        .map_err(from_sqlx_error)?;
+        .map_err(|_| ChatSessionError::RepoFailure("Failed to create chat session".to_string()))?;
         Ok(row.into())
     }
 
@@ -40,7 +43,56 @@ impl ChatSessionRepository for SqlxChatSessionRepository {
         )
         .fetch_one(&self.pool)
         .await
-        .map_err(from_sqlx_error)?;
+        .map_err(|_| ChatSessionError::NotFound)?;
         Ok(row.into())
+    }
+}
+
+// ChatMessageRepository implementation
+
+pub struct SqlxChatMessageRepository {
+    pool: PgPool,
+}
+
+impl SqlxChatMessageRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ChatMessageRepository for SqlxChatMessageRepository {
+    async fn create(&self, message: ChatMessage) -> Result<ChatMessage, ChatSessionError> {
+        let row = ChatMessageRow::from(message);
+        let row = sqlx::query_as!(
+            ChatMessageRow,
+            "INSERT INTO chat_messages (id, session_id, role, content, created_at) VALUES ($1, $2, $3, $4, $5) RETURNING *",
+            row.id,
+            row.session_id,
+            row.role,
+            row.content,
+            row.created_at,
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|_| ChatSessionError::RepoFailure("Failed to create chat message".to_string()))?;
+        Ok(row.into())
+    }
+
+    async fn list_by_session_id(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Vec<ChatMessage>, ChatSessionError> {
+        let session_id: Uuid = session_id.into();
+        let rows = sqlx::query_as!(
+            ChatMessageRow,
+            "SELECT * FROM chat_messages WHERE session_id = $1 ORDER BY created_at ASC",
+            session_id,
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|_| ChatSessionError::RepoFailure("Failed to list chat messages".to_string()))?;
+
+        Ok(rows.into_iter().map(|row| row.into()).collect())
     }
 }

--- a/backend/crates/infra/src/sqlx/chat/types.rs
+++ b/backend/crates/infra/src/sqlx/chat/types.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
-use domain::chat::ChatSession;
-use domain::chat::{SessionId, SessionTitle};
+use domain::chat::{ChatMessage, MessageId, MessageRole};
+use domain::chat::{ChatSession, SessionId, SessionTitle};
 use domain::shared::UserId;
+use std::str::FromStr;
 use uuid::Uuid;
 
 #[derive(Debug, sqlx::FromRow)]
@@ -33,6 +34,39 @@ impl From<ChatSessionRow> for ChatSession {
             title: SessionTitle::from(row.title),
             created_at: row.created_at,
             updated_at: row.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+pub struct ChatMessageRow {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub role: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<ChatMessage> for ChatMessageRow {
+    fn from(message: ChatMessage) -> Self {
+        Self {
+            id: message.id.into(),
+            session_id: message.session_id.into(),
+            role: message.role.to_string(),
+            content: message.content,
+            created_at: message.created_at,
+        }
+    }
+}
+
+impl From<ChatMessageRow> for ChatMessage {
+    fn from(row: ChatMessageRow) -> Self {
+        Self {
+            id: MessageId::from(row.id),
+            session_id: SessionId::from(row.session_id),
+            role: MessageRole::from_str(&row.role).unwrap(),
+            content: row.content,
+            created_at: row.created_at,
         }
     }
 }

--- a/backend/crates/platform-api/src/dtos/chat/message.rs
+++ b/backend/crates/platform-api/src/dtos/chat/message.rs
@@ -1,0 +1,36 @@
+use chrono::{DateTime, Utc};
+use domain::chat::messages::ChatMessage;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChatMessageCreateRequest {
+    pub role: String, // "user"
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChatMessageResponse {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub role: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<ChatMessage> for ChatMessageResponse {
+    fn from(message: ChatMessage) -> Self {
+        Self {
+            id: message.id.into(),
+            session_id: message.session_id.into(),
+            role: message.role.to_string(),
+            content: message.content,
+            created_at: message.created_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChatMessageListResponse {
+    pub messages: Vec<ChatMessageResponse>,
+}

--- a/backend/crates/platform-api/src/dtos/chat/mod.rs
+++ b/backend/crates/platform-api/src/dtos/chat/mod.rs
@@ -1,1 +1,2 @@
+pub mod message;
 pub mod session;

--- a/backend/crates/platform-api/src/routes/chat/messages.rs
+++ b/backend/crates/platform-api/src/routes/chat/messages.rs
@@ -1,0 +1,59 @@
+use crate::app::AppState;
+use crate::dtos::chat::message::{
+    ChatMessageCreateRequest, ChatMessageListResponse, ChatMessageResponse,
+};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use domain::chat::errors::ChatSessionError;
+use domain::chat::values::{MessageRole, SessionId};
+use std::str::FromStr;
+use uuid::Uuid;
+
+pub async fn get_chat_messages(
+    State(state): State<AppState>,
+    Path(session_id): Path<Uuid>,
+) -> Result<Json<ChatMessageListResponse>, impl IntoResponse> {
+    let session_id = SessionId::from(session_id);
+    match state.chat_session_service.get_messages(session_id).await {
+        Ok(messages) => {
+            let response = ChatMessageListResponse {
+                messages: messages
+                    .into_iter()
+                    .map(ChatMessageResponse::from)
+                    .collect(),
+            };
+            Ok(Json(response))
+        }
+        Err(_) => Err((StatusCode::NOT_FOUND, "Chat session not found")),
+    }
+}
+
+pub async fn create_chat_message(
+    State(state): State<AppState>,
+    Path(session_id): Path<Uuid>,
+    Json(request): Json<ChatMessageCreateRequest>,
+) -> Result<Json<ChatMessageResponse>, impl IntoResponse> {
+    let session_id = SessionId::from(session_id);
+
+    let role = match MessageRole::from_str(&request.role) {
+        Ok(r) => r,
+        Err(_) => return Err((StatusCode::BAD_REQUEST, "Invalid role")),
+    };
+
+    match state
+        .chat_session_service
+        .add_message(session_id, role, request.content)
+        .await
+    {
+        Ok(message) => Ok(Json(ChatMessageResponse::from(message))),
+        Err(ChatSessionError::NotFound) => Err((StatusCode::NOT_FOUND, "Chat session not found")),
+        Err(_) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to create chat message",
+        )),
+    }
+}

--- a/backend/crates/platform-api/src/routes/chat/mod.rs
+++ b/backend/crates/platform-api/src/routes/chat/mod.rs
@@ -1,13 +1,19 @@
+pub mod messages;
 pub mod sessions;
 
-use crate::app::AppState;
 use axum::{
     Router,
     routing::{get, post},
 };
 
+use crate::app::AppState;
+
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/sessions", post(sessions::create_chat_session))
         .route("/sessions/{session_id}", get(sessions::get_chat_session))
+        .route(
+            "/sessions/{session_id}/messages",
+            get(messages::get_chat_messages).post(messages::create_chat_message),
+        )
 }

--- a/backend/crates/platform-api/tests/test_chat_messages.rs
+++ b/backend/crates/platform-api/tests/test_chat_messages.rs
@@ -1,0 +1,114 @@
+use axum::http::StatusCode;
+use serde_json::json;
+use uuid::Uuid;
+
+mod common;
+
+#[tokio::test]
+async fn test_add_message_and_list() {
+    let app = common::spawn_app().await;
+    let client = reqwest::Client::new();
+
+    // Create session
+    let response = client
+        .post(format!("{}/api/v1/chat/sessions", &app.address))
+        .json(&json!({
+            "title": "Test Session"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let session_id = body["id"].as_str().expect("Missing id in response");
+
+    // Add message
+    let response = client
+        .post(format!(
+            "{}/api/v1/chat/sessions/{}/messages",
+            &app.address, session_id
+        ))
+        .json(&json!({
+            "role": "user",
+            "content": "Hello, world!"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    assert_eq!(body["role"], "user");
+    assert_eq!(body["content"], "Hello, world!");
+
+    // List messages
+    let response = client
+        .get(format!(
+            "{}/api/v1/chat/sessions/{}/messages",
+            &app.address, session_id
+        ))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let messages = body["messages"].as_array().expect("Missing messages array");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["content"], "Hello, world!");
+}
+
+#[tokio::test]
+async fn test_list_messages_empty_session() {
+    let app = common::spawn_app().await;
+    let client = reqwest::Client::new();
+
+    // Create session
+    let response = client
+        .post(format!("{}/api/v1/chat/sessions", &app.address))
+        .json(&json!({
+            "title": "Empty Session"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let session_id = body["id"].as_str().expect("Missing id in response");
+
+    // List messages
+    let response = client
+        .get(format!(
+            "{}/api/v1/chat/sessions/{}/messages",
+            &app.address, session_id
+        ))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = response.json().await.expect("Failed to parse response");
+    let messages = body["messages"].as_array().expect("Missing messages array");
+    assert_eq!(messages.len(), 0);
+}
+
+#[tokio::test]
+async fn test_add_message_invalid_session() {
+    let app = common::spawn_app().await;
+    let client = reqwest::Client::new();
+    let invalid_id = Uuid::new_v4();
+
+    // Add message
+    let response = client
+        .post(format!(
+            "{}/api/v1/chat/sessions/{}/messages",
+            &app.address, invalid_id
+        ))
+        .json(&json!({
+            "role": "user",
+            "content": "Hello, world!"
+        }))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
# Chat Messages API Implementation
## The following APIs are implemented:

* GET /chat/sessions/{sessionId}/messages
* POST /chat/sessions/{sessionId}/messages

## The following test cases are added:
* test_add_message_and_list
* test_list_messages_empty_session
* test_add_message_invalid_session